### PR TITLE
Fix issue #1177

### DIFF
--- a/webview/platforms/gtk.py
+++ b/webview/platforms/gtk.py
@@ -401,7 +401,7 @@ class BrowserView:
 
         if response == gtk.ResponseType.OK:
             if dialog_type == SAVE_DIALOG:
-                file_name = dialog.get_filename()
+                file_name = (dialog.get_filename(),)
             else:
                 file_name = dialog.get_filenames()
         else:


### PR DESCRIPTION
This simple change fixes the behavior I exposed in issue #1177 by making the type returned by `create_file_dialog` alsways consistent (a tuple of file pathes).